### PR TITLE
Favorites endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ const configuration = require('./knexfile')[environment];
 var indexRouter = require('./routes/index');
 var papersRouter = require('./routes/api/v1/papers');
 var forecastRouter = require('./routes/api/v1/forecast');
+var favoritesRouter = require('./routes/api/v1/favorites');
 
 var app = express();
 
@@ -22,5 +23,6 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', indexRouter);
 app.use('/api/v1/papers', papersRouter);
 app.use('/api/v1/forecast', forecastRouter);
+app.use('/api/v1/favorites', favoritesRouter);
 
 module.exports = app;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -21,7 +21,6 @@ router.post('/', (request, response) => {
   // 2. check api_key in users and return user
   database('users')
     .where('api_key', info['api_key'])
-    .select()
     .first()
     .then(user => {
       if(user) {
@@ -41,7 +40,6 @@ router.post('/', (request, response) => {
           .then(data => {
             if(data === undefined){
               // no latLong found
-              console.log(favorite[0], info['location'])
               database('favorites')
                 .where({ id: favorite[0] })
                 .del()

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -56,12 +56,10 @@ router.post('/', (request, response) => {
           })
       })
     })
-
-
-    // Returns [ { id: 42, title: "The Hitchhiker's Guide to the Galaxy" } ]
-
-  // 5. .catch error handling
-
+  // 5. catch error handling
+  .catch(error => {
+    response.status(500).json({error})
+  })
 });
 
 // 4. look up lat and long of favorite to add update row in table

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -39,7 +39,20 @@ router.post('/', (request, response) => {
       .then(async(favorite) => {
         addLatLong(favorite, info['location'])
           .then(data => {
-            response.send(data);
+            if(data === undefined){
+              // no latLong found
+              console.log(favorite[0], info['location'])
+              database('favorites')
+                .where({ id: favorite[0] })
+                .del()
+                .then(()=>{
+                  return response.status(404).send("Location not found on Google Maps, please enter a different location")
+                })
+            } else {
+              return response
+              .status(200)
+              .json({"message": `${info['location']} has been added to your favorites`});
+            }
           })
       })
     })

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -5,15 +5,63 @@ const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
 
+router.post('/', (request, response) => {
+  // 1. check request body comes with location and api_key
 
-router.get('/', (request, response) => {
-  // database('papers').select()
-  //   .then((papers) => {
-      response.status(200).send('favorites');
-    // })
-    // .catch((error) => {
-    //   response.status(500).json({ error });
-    // });
+  const info = request.body;
+  console.log(info);
+
+  for (let requiredParameter of ['location', 'api_key']) {
+    if (!info[requiredParameter]) {
+      return response
+        .status(422)
+        .send({ error: `Expected format: { location: <String>, api_key: <String> }. You're missing a "${requiredParameter}" property.` });
+    }
+  }
+  // 2. check api_key in users and return user
+  database('users')
+    .where('api_key', info['api_key'])
+    .select()
+    .first()
+    .then(user => {
+      if(user) {
+        return user
+      } else {
+        return response
+          .status(401)
+          .json({"message": "Unauthorized request"})
+      }
+    })
+    .then(user => {
+      // 3. add favorite with user reference
+      database('favorites').insert({location: info['location'], user_id: user.id}, 'id')
+      .then(favorite => {
+        response.json(favorite)
+      })
+    })
+  // 4. look up lat and long of favorite to add update row in table
+  // 5. .catch error handling
+
+  // // find paper_id in papers db and return error if not found
+  // database('papers')
+  //   .where('id', footnote['paper_id'])
+  //   .select()
+  //   .then(papers => {
+  //     if(papers.length === 0) {
+  //       return response
+  //       .status(404)
+  //       .send({ error: `Could not find paper with id ${footnote['paper_id']}` });
+  //     } else {
+  //       // if paper is found in db, insert footnote into footnotes db
+  //       database('footnotes').insert(footnote, 'id')
+  //       .then(footnote => {
+  //         response.status(201).json({id: footnote[0]});
+  //       })
+  //       .catch(error => {
+  //         response.status(500).json({ error });
+  //       });
+  //     }
+  //   })
 });
 
 module.exports = router;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -66,12 +66,13 @@ router.post('/', (request, response) => {
 async function addLatLong(fav, location) {
   let fav_id = fav[0];
   let googleInfo = await fetchGoogle(location);
-  let latLong = await googleInfo.results[0].geometry.location;
-  let updated = await database('favorites')
+  if(googleInfo.results.length > 0){
+    let latLong = await googleInfo.results[0].geometry.location;
+    let updated = await database('favorites')
     .where({id: fav_id})
     .update({latitude: latLong.lat, longitude: latLong.lng}, ['id', 'latitude', 'longitude'])
-  console.log(updated);
-  return updated;
+    return updated;
+  }
 }
 
 async function fetchGoogle(loc) {

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,0 +1,19 @@
+var express = require('express');
+var router = express.Router();
+
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+
+router.get('/', (request, response) => {
+  // database('papers').select()
+  //   .then((papers) => {
+      response.status(200).send('favorites');
+    // })
+    // .catch((error) => {
+    //   response.status(500).json({ error });
+    // });
+});
+
+module.exports = router;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -34,34 +34,41 @@ router.post('/', (request, response) => {
     })
     .then(user => {
       // 3. add favorite with user reference
-      database('favorites').insert({location: info['location'], user_id: user.id}, 'id')
-      .then(favorite => {
-        response.json(favorite)
+      database('favorites').insert({location: info['location'],
+                                    user_id: user.id}, 'id')
+      .then(async(favorite) => {
+        addLatLong(favorite)
+          .then(data => {
+            response.send(data);
+          })
       })
     })
-  // 4. look up lat and long of favorite to add update row in table
+
+
+    // Returns [ { id: 42, title: "The Hitchhiker's Guide to the Galaxy" } ]
+
   // 5. .catch error handling
 
-  // // find paper_id in papers db and return error if not found
-  // database('papers')
-  //   .where('id', footnote['paper_id'])
-  //   .select()
-  //   .then(papers => {
-  //     if(papers.length === 0) {
-  //       return response
-  //       .status(404)
-  //       .send({ error: `Could not find paper with id ${footnote['paper_id']}` });
-  //     } else {
-  //       // if paper is found in db, insert footnote into footnotes db
-  //       database('footnotes').insert(footnote, 'id')
-  //       .then(footnote => {
-  //         response.status(201).json({id: footnote[0]});
-  //       })
-  //       .catch(error => {
-  //         response.status(500).json({ error });
-  //       });
-  //     }
-  //   })
 });
+
+// 4. look up lat and long of favorite to add update row in table
+async function addLatLong(fav) {
+  let fav_id = fav[0]
+  let updated = await database('favorites')
+    .where({id: fav_id})
+    .update({latitude: 4322.22, longitude: 3333.33}, ['id', 'latitude', 'longitude'])
+
+  console.log(updated);
+  return updated;
+}
+
+// console.log(favorite, favorite[0]);
+// database('favorites')
+//   .where({ id: favorite[0] })
+//   .update({ latitude: 100.00}, ['id', 'latitude'])
+// })
+// .then(info => {
+// response.send(info)
+// })
 
 module.exports = router;


### PR DESCRIPTION
Add `post` endpoint for adding favorites. Also added async await functions to add the lat and long to db.

Current implementation is inefficient in its calls to the database: 1. Create favorite, regardless if location is valid by google, 2. If no latLong is found from google, then delete favorite and throw a 404 error. 

Ideally, I'd be able to check if latLong existed before creating a `favorite` in the db.

@lrs8810 or @Not-Zorro, do you have any thoughts on how to remove the extra db call?